### PR TITLE
lesson: 카프카 설정 및 실습

### DIFF
--- a/com.kafka-sample.consumer/src/main/java/com/kafka_sample/consumer/ConsumerApplicationKafkaConfig.java
+++ b/com.kafka-sample.consumer/src/main/java/com/kafka_sample/consumer/ConsumerApplicationKafkaConfig.java
@@ -1,0 +1,49 @@
+package com.kafka_sample.consumer;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+// 이 클래스는 Kafka 컨슈머 설정을 위한 Spring 설정 클래스입니다.
+@EnableKafka // Kafka 리스너를 활성화하는 어노테이션입니다.
+@Configuration // Spring 설정 클래스로 선언하는 어노테이션입니다.
+public class ConsumerApplicationKafkaConfig {
+
+	// Kafka 컨슈머 팩토리를 생성하는 빈을 정의합니다.
+	// ConsumerFactory는 Kafka 컨슈머 인스턴스를 생성하는 데 사용됩니다.
+	// 각 컨슈머는 이 팩토리를 통해 생성된 설정을 기반으로 작동합니다.
+	@Bean
+	public ConsumerFactory<String, String> consumerFactory() {
+		// 컨슈머 팩토리 설정을 위한 맵을 생성합니다.
+		Map<String, Object> configProps = new HashMap<>();
+		// Kafka 브로커의 주소를 설정합니다.
+		configProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+		// 메시지 키의 디시리얼라이저 클래스를 설정합니다.
+		configProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+		// 메시지 값의 디시리얼라이저 클래스를 설정합니다.
+		configProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+		// 설정된 프로퍼티로 DefaultKafkaConsumerFactory를 생성하여 반환합니다.
+		return new DefaultKafkaConsumerFactory<>(configProps);
+	}
+
+	// Kafka 리스너 컨테이너 팩토리를 생성하는 빈을 정의합니다.
+	// ConcurrentKafkaListenerContainerFactory는 Kafka 메시지를 비동기적으로 수신하는 리스너 컨테이너를 생성하는 데 사용됩니다.
+	// 이 팩토리는 @KafkaListener 어노테이션이 붙은 메서드들을 실행할 컨테이너를 제공합니다.
+	@Bean
+	public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory() {
+		// ConcurrentKafkaListenerContainerFactory를 생성합니다.
+		ConcurrentKafkaListenerContainerFactory<String, String> factory = new ConcurrentKafkaListenerContainerFactory<>();
+		// 컨슈머 팩토리를 리스너 컨테이너 팩토리에 설정합니다.
+		factory.setConsumerFactory(consumerFactory());
+		// 설정된 리스너 컨테이너 팩토리를 반환합니다.
+		return factory;
+	}
+}

--- a/com.kafka-sample.consumer/src/main/java/com/kafka_sample/consumer/ConsumerEndpoint.java
+++ b/com.kafka-sample.consumer/src/main/java/com/kafka_sample/consumer/ConsumerEndpoint.java
@@ -1,0 +1,42 @@
+package com.kafka_sample.consumer;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class ConsumerEndpoint {
+
+	// 이 메서드는 Kafka에서 메시지를 소비하는 리스너 메서드입니다.
+	// @KafkaListener 어노테이션은 이 메서드를 Kafka 리스너로 설정합니다.
+	@KafkaListener(groupId = "group_a", topics = "topic1")
+	// Kafka 토픽 "test-topic"에서 메시지를 수신하면 이 메서드가 호출됩니다.
+	// groupId는 컨슈머 그룹을 지정하여 동일한 그룹에 속한 다른 컨슈머와 메시지를 분배받습니다.
+	public void consumeFromGroupA(String message) {
+		log.info("Group A consumed message from topic1: " + message);
+	}
+
+	// 동일한 토픽을 다른 그룹 ID로 소비하는 또 다른 리스너 메서드입니다.
+	@KafkaListener(groupId = "group_b", topics = "topic1")
+	public void consumeFromGroupB(String message) {
+		log.info("Group B consumed message from topic1: " + message);
+	}
+
+	// 다른 토픽을 다른 그룹 ID로 소비하는 리스너 메서드입니다.
+	@KafkaListener(groupId = "group_c", topics = "topic2")
+	public void consumeFromTopicC(String message) {
+		log.info("Group C consumed message from topic2: " + message);
+	}
+
+	// 다른 토픽을 다른 그룹 ID로 소비하는 리스너 메서드입니다.
+	@KafkaListener(groupId = "group_c", topics = "topic3")
+	public void consumeFromTopicD(String message) {
+		log.info("Group C consumed message from topic3: " + message);
+	}
+
+	@KafkaListener(groupId = "group_d", topics = "topic4")
+	public void consumeFromPartition0(String message) {
+		log.info("Group D consumed message from topic4: " + message);
+	}
+}

--- a/com.kafka-sample.consumer/src/main/resources/application.properties
+++ b/com.kafka-sample.consumer/src/main/resources/application.properties
@@ -1,1 +1,7 @@
 spring.application.name=consumer
+
+server.port=8091
+
+spring.kafka.bootstrap-servers=localhost:9092
+spring.kafka.consumer.key-deserializer=org.apache.kafka.common.serialization.StringDeserializer
+spring.kafka.consumer.value-deserializer=org.apache.kafka.common.serialization.StringDeserializer


### PR DESCRIPTION
- close #7 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * Apache Kafka로부터 메시지를 소비하고 처리할 수 있습니다.
  * 여러 토픽 및 소비자 그룹에서 메시지 수신을 지원합니다.

* **설정**
  * 애플리케이션 서버 포트가 8091로 설정되었습니다.
  * Kafka 브로커 연결 정보가 구성되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->